### PR TITLE
Optionally use fletch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,9 @@ list(APPEND CMAKE_MODULE_PATH
   "${PROJECT_SOURCE_DIR}/cmake/thirdparty"
   )
 
+find_package(kwiver REQUIRED)
+find_package(fletch QUIET)
+find_package(qtExtensions REQUIRED)
 find_package(Qt5 5.10 REQUIRED COMPONENTS
   Test
   Widgets
@@ -27,8 +30,6 @@ find_package(Qt5 5.10 REQUIRED COMPONENTS
   Gui
   Core
   )
-find_package(qtExtensions REQUIRED)
-find_package(kwiver REQUIRED)
 find_package(Threads REQUIRED)
 find_package(Git)
 find_package(Sphinx)


### PR DESCRIPTION
Add logic to optionally attempt to use fletch, the collection of third-party dependencies which is also used by KWIVER. This may simplify providing Krest's own dependencies. Also, rearrange find calls to be in decreasing order of dependence, which should reduce the chances of finding different versions of dependencies when both Krest and another dependency need the same package.