### PR TITLE
Expose Player placeholder text

### DIFF
--- a/krest/gui/Player.cpp
+++ b/krest/gui/Player.cpp
@@ -231,7 +231,7 @@ public:
   QMatrix4x4 inverseHomography;
   QSize homographyImageSize;
 
-  QString noVideoText = QStringLiteral("Right-click to load imagery");
+  QString placeholderText = QStringLiteral("Unavailable");
 
   QVector<float> detectedObjectVertexData;
   QVector<DetectionInfo> detectedObjectVertexIndices;
@@ -874,10 +874,17 @@ void Player::setHomographyImageSize(QSize size)
 }
 
 // ----------------------------------------------------------------------------
-void Player::setNoVideoText(QString const& text)
+QString Player::placeholderText() const
 {
   QTE_D();
-  d->noVideoText = text;
+  return d->placeholderText;
+}
+
+// ----------------------------------------------------------------------------
+void Player::setPlaceholderText(QString const& text)
+{
+  QTE_D();
+  d->placeholderText = text;
 }
 
 // ----------------------------------------------------------------------------
@@ -982,7 +989,7 @@ void Player::paintEvent(QPaintEvent* event)
   {
     static auto const noFrame = QStringLiteral("(NO IMAGE)");
 
-    auto const& text = (d->videoSource ? noFrame : d->noVideoText);
+    auto const& text = (d->videoSource ? noFrame : d->placeholderText);
 
     QPainter painter{this};
     painter.setPen(Qt::white);

--- a/krest/gui/Player.hpp
+++ b/krest/gui/Player.hpp
@@ -83,6 +83,9 @@ class KREST_GUI_EXPORT Player : public QOpenGLWidget
   Q_PROPERTY(QColor pendingColor READ pendingColor
              WRITE setPendingColor NOTIFY pendingColorChanged)
 
+  Q_PROPERTY(QString placeholderText READ placeholderText
+             WRITE setPlaceholderText)
+
 public:
   explicit Player(QWidget* parent = nullptr);
   ~Player() override;
@@ -109,6 +112,8 @@ public:
   QColor defaultColor() const;
   QColor selectionColor() const;
   QColor pendingColor() const;
+
+  QString placeholderText() const;
 
 signals:
   void zoomChanged(float zoom) const;
@@ -147,6 +152,8 @@ public slots:
   void setSelectionColor(QColor const& color);
   void setPendingColor(QColor const& color);
 
+  void setPlaceholderText(QString const& text);
+
   void setCenterToTrack(qint64 id, kwiver::vital::timestamp::time_t time);
 
   void setShadowTrackModel(QObject* source, QAbstractItemModel* model);
@@ -155,8 +162,6 @@ public slots:
 
 protected:
   QTE_DECLARE_PRIVATE(Player)
-
-  void setNoVideoText(QString const& text);
 
   void initializeGL() override;
   void paintGL() override;


### PR DESCRIPTION
Rename API to set text displayed by `Player` when no image is available, and promote it to a proper, public property. There are a bunch of users of this, now, and each one seems to want different text, and the old default was only really suitable for the NOAA GUI; having to subclass the Player everywhere just to be able to change the placeholder text was getting annoying.