### PR TITLE
Fix image to texture conversion

### DIFF
--- a/krest/core/AutoLevelsTask.cpp
+++ b/krest/core/AutoLevelsTask.cpp
@@ -247,7 +247,7 @@ void AutoLevelsTask::execute()
   auto const channelOffset = (pt.type == PixelType::SIGNED ? 0.5 : 0.0);
   auto const channelScale =
     imageChannelScale(pt) / static_cast<double>(channels);
-  auto chanelWeights = std::vector<double>(channels, channelScale);
+  auto channelWeights = std::vector<double>(channels, channelScale);
 
   // Examine image
   while (stride--)
@@ -262,7 +262,7 @@ void AutoLevelsTask::execute()
         }
 
         // Get pixel value
-        auto const v = (*pf)(image, i << stride, j << stride, chanelWeights);
+        auto const v = (*pf)(image, i << stride, j << stride, channelWeights);
         auto const vn = std::min(std::max(0.0, v + channelOffset), 1.0);
 
         // Get bucket index and increment bucket count

--- a/krest/core/ImageUtils.cpp
+++ b/krest/core/ImageUtils.cpp
@@ -233,9 +233,9 @@ void KREST_CORE_EXPORT imageToTexture(
   auto const yk = image.height();
   auto const ck = image.depth();
 
-  auto const xs = image.w_step();
-  auto const ys = image.h_step();
-  auto cs = image.d_step();
+  auto const xs = image.w_step() * ss;
+  auto const ys = image.h_step() * ss;
+  auto cs = image.d_step() * ss;
 
   auto* first = reinterpret_cast<char const*>(image.first_pixel());
   auto const isPlanePacked = (std::abs(cs) > std::abs(ys));


### PR DESCRIPTION
Adjust stride computation in image to texture conversion. We want strides reported in bytes, and our logic to check for valid strides is based on the same, however KWIVER reports strides in increments of the value type. This was fine for 8-bit images and seems to have been working by accident for single-channel 16-bit images, but was causing the stride check to incorrectly reject some multi-channel 16-bit images.