### PR TITLE
Set C++ standard to C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ find_package(Threads REQUIRED)
 find_package(Git)
 find_package(Sphinx)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 set(CMAKE_AUTOMOC 1)


### PR DESCRIPTION
This is necessary due to KWIVER updating its own standard to C++17.